### PR TITLE
synciwl.sh: support linux-6.5

### DIFF
--- a/synciwl.sh
+++ b/synciwl.sh
@@ -38,7 +38,7 @@ function get_kernel_max()
   [ -d ${driver_path}/cfg ] && driver_path+=/cfg
 
   while read -r filename; do
-    def_device="$(basename ${filename} .c)"
+    def_device="$(basename ${filename} .c | tr '[:lower:]' '[:upper:]')"
     while read -r prefix; do
       device="$(echo "${prefix}" | awk -F- '{ print $2 }')"
       [ -z "${device}" ] && continue
@@ -52,6 +52,8 @@ function get_kernel_max()
       [ -z "${kernel_max}" ] && kernel_max="$(grep "#define[[:space:]]*IWL_${def_device}_UCODE_API_MAX" ${filename} | awk '{ print $3 }')"
       [ -n "${kernel_max}" ] || continue
 
+      # since linux-6.5 the trailing dash was removed - add it back
+      [[ "${prefix}" != *- ]] && prefix="${prefix}-"
       echo "${device} ${prefix} ${kernel_max}"
     done <<< "$(grep "#define[[:space:]]*IWL.*_FW_PRE[[:space:]]*\".*\"$" ${filename} | awk '{ print $3 }' | sed 's/"//g')"
   done <<< "$(ls -1 ${driver_path}/*.c)"


### PR DESCRIPTION
### The script now supports linux-6.5 and well as < 6.5

Since https://github.com/torvalds/linux/commit/19898ce9cf8a33e0ac35cb4c7f68de297cc93cb2 (linux-6.5) the `22000.c` has been split with three additional files `cfg/ax210.c cfg/bz.c cfg/sc.c`. 
- def_device is used by grep and the code is uppercase, whilst file names are lower. It worked previously because all def_device were only numeric.

Since https://github.com/torvalds/linux/commit/31aeae2446d50665b6ec51d564f5e7fe751d53d4 (linux-6.5) the trailing dashes have been removed. 
- add the dash back in the script to allow compatibility with both of < 6.5 and 6.5.